### PR TITLE
#12 sscanf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# VS code config files
+.vscode/

--- a/ASMC_SRC/SRC/Data.cpp
+++ b/ASMC_SRC/SRC/Data.cpp
@@ -121,7 +121,7 @@ int Data::readMap(string hapsFileRoot) {
     vector <string> splitStr;
     istringstream iss(line); string buf; while (iss >> buf) splitStr.push_back(buf);
     string ID = splitStr[1];
-    float gen = StringUtils::stof(splitStr[2]) / 100.f;
+    float gen = std::stof(splitStr[2]) / 100.f;
     int phys = std::stoi(splitStr[3]);
     SNP_IDs[pos] = ID;
     geneticPositions[pos] = gen;

--- a/ASMC_SRC/SRC/Data.cpp
+++ b/ASMC_SRC/SRC/Data.cpp
@@ -122,7 +122,7 @@ int Data::readMap(string hapsFileRoot) {
     istringstream iss(line); string buf; while (iss >> buf) splitStr.push_back(buf);
     string ID = splitStr[1];
     float gen = StringUtils::stof(splitStr[2]) / 100.f;
-    int phys = StringUtils::stoi(splitStr[3]);
+    int phys = std::stoi(splitStr[3]);
     SNP_IDs[pos] = ID;
     geneticPositions[pos] = gen;
     physicalPositions[pos] = phys;

--- a/ASMC_SRC/SRC/DecodingQuantities.cpp
+++ b/ASMC_SRC/SRC/DecodingQuantities.cpp
@@ -75,7 +75,7 @@ void DecodingQuantities::createFromGzippedText(const char *fileName) {
       vector <string> inSplitString; istringstream iss(line); string buf; while (iss >> buf) inSplitString.push_back(buf);
       timeVector = vector <float> (inSplitString.size());
       for (unsigned int i = 0; i < inSplitString.size(); i++) {
-        timeVector[i] = StringUtils::stof(inSplitString[i]);
+        timeVector[i] = std::stof(inSplitString[i]);
       }
       // cout << "Parsed TimeVector " << timeVector.size() << endl;
       continue;
@@ -98,7 +98,7 @@ void DecodingQuantities::createFromGzippedText(const char *fileName) {
         exit(1);
       }
       for (unsigned int i = 0; i < inSplitString.size(); i++) {
-        expectedTimes[i] = StringUtils::stof(inSplitString[i]);
+        expectedTimes[i] = std::stof(inSplitString[i]);
       }
       // cout << "Parsed ExpectedTimes " << expectedTimes.size() << endl;
       continue;
@@ -116,7 +116,7 @@ void DecodingQuantities::createFromGzippedText(const char *fileName) {
         exit(1);
       }
       for (unsigned int i = 0; i < inSplitString.size(); i++) {
-        discretization[i] = StringUtils::stof(inSplitString[i]);
+        discretization[i] = std::stof(inSplitString[i]);
       }
       // cout << "Parsed Discretization " << discretization.size() << endl;
       continue;
@@ -136,7 +136,7 @@ void DecodingQuantities::createFromGzippedText(const char *fileName) {
         }
         vector <float> thisEmission = vector <float> (states);
         for (unsigned int i = 0; i < states; i++) {
-          thisEmission[i] = StringUtils::stof(inSplitString[i]);
+          thisEmission[i] = std::stof(inSplitString[i]);
         }
         classicEmissionTable[k] = thisEmission;
       }
@@ -158,7 +158,7 @@ void DecodingQuantities::createFromGzippedText(const char *fileName) {
         }
         vector <float> thisEmission = vector <float> (states);
         for (unsigned int i = 0; i < states; i++) {
-          thisEmission[i] = StringUtils::stof(inSplitString[i]);
+          thisEmission[i] = std::stof(inSplitString[i]);
         }
         compressedEmissionTable[k] = thisEmission;
       }
@@ -182,7 +182,7 @@ void DecodingQuantities::createFromGzippedText(const char *fileName) {
         vector <float> CSFSline = vector <float> (states);
         thisCSFS.push_back(CSFSline);
         for (unsigned int i = 0; i < states; i++) {
-          thisCSFS[k][i] = StringUtils::stof(inSplitString[i]);
+          thisCSFS[k][i] = std::stof(inSplitString[i]);
         }
       }
       CSFSmap[undistinguishedIndex] = thisCSFS;
@@ -206,7 +206,7 @@ void DecodingQuantities::createFromGzippedText(const char *fileName) {
         vector <float> CSFSline = vector <float> (states);
         thisCSFS.push_back(CSFSline);
         for (unsigned int i = 0; i < states; i++) {
-          thisCSFS[k][i] = StringUtils::stof(inSplitString[i]);
+          thisCSFS[k][i] = std::stof(inSplitString[i]);
         }
       }
       foldedCSFSmap[undistinguishedIndex] = thisCSFS;
@@ -229,7 +229,7 @@ void DecodingQuantities::createFromGzippedText(const char *fileName) {
         vector <float> CSFSline = vector <float> (states);
         thisCSFS.push_back(CSFSline);
         for (unsigned int i = 0; i < states; i++) {
-          thisCSFS[k][i] = StringUtils::stof(inSplitString[i]);
+          thisCSFS[k][i] = std::stof(inSplitString[i]);
         }
       }
       ascertainedCSFSmap[undistinguishedIndex] = thisCSFS;
@@ -252,7 +252,7 @@ void DecodingQuantities::createFromGzippedText(const char *fileName) {
         vector <float> CSFSline = vector <float> (states);
         thisCSFS.push_back(CSFSline);
         for (unsigned int i = 0; i < states; i++) {
-          thisCSFS[k][i] = StringUtils::stof(inSplitString[i]);
+          thisCSFS[k][i] = std::stof(inSplitString[i]);
         }
       }
       foldedAscertainedCSFSmap[undistinguishedIndex] = thisCSFS;
@@ -276,45 +276,45 @@ void DecodingQuantities::createFromGzippedText(const char *fileName) {
       if (currentType == DataType::ColumnRatios) {
         columnRatios = vector <float> (states, 0.0);
         for (unsigned int i = 0; i < splitString.size(); i++) {
-          columnRatios[i] = StringUtils::stof(splitString[i]);
+          columnRatios[i] = std::stof(splitString[i]);
         }
       } else if (currentType == DataType::initialStateProb) {
         initialStateProb = vector <float> (states, 0.0);
         for (unsigned int i = 0; i < splitString.size(); i++) {
-          initialStateProb[i] = StringUtils::stof(splitString[i]);
+          initialStateProb[i] = std::stof(splitString[i]);
         }
       } else if (currentType == DataType::RowRatios) {
         vector <float> thisRow(states, 0.0);
         for (unsigned int i = 1; i < splitString.size(); i++) {
-          thisRow[i-1] = StringUtils::stof(splitString[i]);
+          thisRow[i-1] = std::stof(splitString[i]);
         }
-        float index = StringUtils::stof(splitString[0]);
+        float index = std::stof(splitString[0]);
         rowRatioVectors[index] = thisRow;
       } else if (currentType == DataType::Uvectors) {
         vector <float> thisRow(states, 0.0);
         for (unsigned int i = 1; i < splitString.size(); i++) {
-          thisRow[i-1] = StringUtils::stof(splitString[i]);
+          thisRow[i-1] = std::stof(splitString[i]);
         }
-        float index = StringUtils::stof(splitString[0]);
+        float index = std::stof(splitString[0]);
         Uvectors[index] = thisRow;
       } else if (currentType == DataType::Bvectors) {
         vector <float> thisRow(states, 0.0);
         for (unsigned int i = 1; i < splitString.size(); i++) {
-          thisRow[i-1] = StringUtils::stof(splitString[i]);
+          thisRow[i-1] = std::stof(splitString[i]);
         }
-        float index = StringUtils::stof(splitString[0]);
+        float index = std::stof(splitString[0]);
         Bvectors[index] = thisRow;
       } else if (currentType == DataType::Dvectors) {
         vector <float> thisRow(states, 0.0);
         for (unsigned int i = 1; i < splitString.size(); i++) {
-          thisRow[i-1] = StringUtils::stof(splitString[i]);
+          thisRow[i-1] = std::stof(splitString[i]);
         }
-        float index = StringUtils::stof(splitString[0]);
+        float index = std::stof(splitString[0]);
         Dvectors[index] = thisRow;
       } else if (currentType == DataType::HomozygousEmissions) {
         vector <float> thisRow(states, 0.0);
         for (unsigned int i = 1; i < splitString.size(); i++) {
-          thisRow[i-1] = StringUtils::stof(splitString[i]);
+          thisRow[i-1] = std::stof(splitString[i]);
         }
         int index = std::stoi(splitString[0]);
         homozygousEmissionMap[index] = thisRow;

--- a/ASMC_SRC/SRC/DecodingQuantities.cpp
+++ b/ASMC_SRC/SRC/DecodingQuantities.cpp
@@ -49,7 +49,7 @@ void DecodingQuantities::createFromGzippedText(const char *fileName) {
     if (firstToken == string("states")) {
       currentType = DataType::States;
       getline(br, line);
-      states = StringUtils::stoi(line);
+      states = std::stoi(line);
       parsedStates = true;
       // cout << "Parsed states " << states << endl;
       continue;
@@ -62,7 +62,7 @@ void DecodingQuantities::createFromGzippedText(const char *fileName) {
       currentType = DataType::CSFSSamples;
       parsedCSFSSamples = true;
       getline(br, line);
-      CSFSSamples = StringUtils::stoi(line);
+      CSFSSamples = std::stoi(line);
       // cout << "Parsed CSFSSamples " << CSFSSamples << endl;
       CSFSmap = vector < vector < vector <float> > > (CSFSSamples - 1);
       foldedCSFSmap = vector < vector < vector <float> > > (CSFSSamples - 1);
@@ -170,7 +170,7 @@ void DecodingQuantities::createFromGzippedText(const char *fileName) {
         cerr << "ERROR. Parsed " << int(currentType) << " before parsing states and number of CSFS samples." << endl;
         exit(1);
       }
-      int undistinguishedIndex = StringUtils::stoi(splitString[1]);
+      int undistinguishedIndex = std::stoi(splitString[1]);
       vector < vector <float> > thisCSFS = vector < vector <float> > ();
       for (int k = 0; k < 3; k++) {
         getline(br, line);
@@ -194,7 +194,7 @@ void DecodingQuantities::createFromGzippedText(const char *fileName) {
         cerr << "ERROR. Parsed " << int(currentType) << " before parsing states and number of CSFS samples." << endl;
         exit(1);
       }
-      int undistinguishedIndex = StringUtils::stoi(splitString[1]);
+      int undistinguishedIndex = std::stoi(splitString[1]);
       vector < vector <float> > thisCSFS = vector < vector <float> > ();
       for (int k = 0; k < 2; k++) {
         getline(br, line);
@@ -217,7 +217,7 @@ void DecodingQuantities::createFromGzippedText(const char *fileName) {
         cerr << "ERROR. Parsed " << int(currentType) << " before parsing states and number of CSFS samples." << endl;
         exit(1);
       }
-      int undistinguishedIndex = StringUtils::stoi(splitString[1]);
+      int undistinguishedIndex = std::stoi(splitString[1]);
       vector < vector <float> > thisCSFS = vector < vector <float> > ();
       for (int k = 0; k < 3; k++) {
         getline(br, line);
@@ -240,7 +240,7 @@ void DecodingQuantities::createFromGzippedText(const char *fileName) {
         cerr << "ERROR. Parsed " << int(currentType) << " before parsing states and number of CSFS samples." << endl;
         exit(1);
       }
-      int undistinguishedIndex = StringUtils::stoi(splitString[1]);
+      int undistinguishedIndex = std::stoi(splitString[1]);
       vector < vector <float> > thisCSFS = vector < vector <float> > ();
       for (int k = 0; k < 2; k++) {
         getline(br, line);
@@ -316,7 +316,7 @@ void DecodingQuantities::createFromGzippedText(const char *fileName) {
         for (unsigned int i = 1; i < splitString.size(); i++) {
           thisRow[i-1] = StringUtils::stof(splitString[i]);
         }
-        int index = StringUtils::stoi(splitString[0]);
+        int index = std::stoi(splitString[0]);
         homozygousEmissionMap[index] = thisRow;
       }
     }

--- a/ASMC_SRC/SRC/FileUtils.cpp
+++ b/ASMC_SRC/SRC/FileUtils.cpp
@@ -105,9 +105,7 @@ int lookupColumnInd(const string &fileName, const string &delimiters, const stri
 double readDoubleNanInf(std::istream &stream) {
   string str;
   stream >> str;
-  double x;
-  sscanf_s(str.c_str(), "%lf", &x);
-  return x;
+  return std::stod(str);
 }
 
 vector < std::pair <string, string> > readFidIids(const string &file) {

--- a/ASMC_SRC/SRC/HMM.hpp
+++ b/ASMC_SRC/SRC/HMM.hpp
@@ -115,7 +115,7 @@ vector <float> readExpectedTimesFromIntervalsFil(const char *fileName) {
       cerr << fileName << " should have \"intervalStart\texpectedCoalescentTime\tintervalEnd\" at each line." << endl;
       exit(1);
     }
-    expCoalTimes.push_back(StringUtils::stof(splitString[1]));
+    expCoalTimes.push_back(std::stof(splitString[1]));
   }
   return expCoalTimes;
 }

--- a/ASMC_SRC/SRC/StringUtils.cpp
+++ b/ASMC_SRC/SRC/StringUtils.cpp
@@ -33,11 +33,6 @@ using std::cout;
 using std::cerr;
 using std::endl;
 
-string itos(int i) {
-  std::ostringstream oss;
-  oss << i;
-  return oss.str();
-}
 string findDelimiters(const string &s, const string &c) {
   string delims;
   for (uint p = 0; p < s.length(); p++)
@@ -98,7 +93,7 @@ vector <string> expandRangeTemplate(const string &str) {
       exit(1);
     }
     for (int i = start; i <= end; i++)
-      ret.push_back(prefix + itos(i) + suffix);
+      ret.push_back(prefix + std::to_string(i) + suffix);
   }
   else
     rangeErrorExit(str, delims);

--- a/ASMC_SRC/SRC/StringUtils.cpp
+++ b/ASMC_SRC/SRC/StringUtils.cpp
@@ -33,11 +33,6 @@ using std::cout;
 using std::cerr;
 using std::endl;
 
-double stod(const string &s) {
-  double d;
-  sscanf_s(s.c_str(), "%lf", &d);
-  return d;
-}
 float stof(const string &s) {
   float f;
   sscanf_s(s.c_str(), "%f", &f);

--- a/ASMC_SRC/SRC/StringUtils.cpp
+++ b/ASMC_SRC/SRC/StringUtils.cpp
@@ -33,11 +33,6 @@ using std::cout;
 using std::cerr;
 using std::endl;
 
-float stof(const string &s) {
-  float f;
-  sscanf_s(s.c_str(), "%f", &f);
-  return f;
-}
 string itos(int i) {
   std::ostringstream oss;
   oss << i;

--- a/ASMC_SRC/SRC/StringUtils.cpp
+++ b/ASMC_SRC/SRC/StringUtils.cpp
@@ -33,14 +33,6 @@ using std::cout;
 using std::cerr;
 using std::endl;
 
-int stoi(const string &s) {
-  int i;
-  if (sscanf_s(s.c_str(), "%d", &i) == 0) {
-    cerr << "ERROR: Could not parse integer from string: " << s << endl;
-    exit(1);
-  }
-  return i;
-}
 double stod(const string &s) {
   double d;
   sscanf_s(s.c_str(), "%lf", &d);
@@ -108,7 +100,7 @@ vector <string> expandRangeTemplate(const string &str) {
     string prefix, suffix;
     if (str[0] != RANGE_DELIMS[0]) prefix = tokens[0];
     if (str[str.length() - 1] != RANGE_DELIMS[2]) suffix = tokens.back();
-    int start = StringUtils::stoi(tokens[startInd]), end = StringUtils::stoi(tokens[endInd]);
+    int start = std::stoi(tokens[startInd]), end = std::stoi(tokens[endInd]);
     if (start > end + 1 || end > start + 1000000) {
       cerr << "ERROR: Invalid range in template string: " << str << endl;
       cerr << "  Start: " << start << endl;

--- a/ASMC_SRC/SRC/StringUtils.hpp
+++ b/ASMC_SRC/SRC/StringUtils.hpp
@@ -24,7 +24,6 @@ namespace StringUtils {
 
 const std::string RANGE_DELIMS = "{:}";
 
-double stod(const std::string &s);
 float stof(const std::string &s);
 std::string itos(int i);
 std::string findDelimiters(const std::string &s, const std::string &c);

--- a/ASMC_SRC/SRC/StringUtils.hpp
+++ b/ASMC_SRC/SRC/StringUtils.hpp
@@ -24,7 +24,6 @@ namespace StringUtils {
 
 const std::string RANGE_DELIMS = "{:}";
 
-float stof(const std::string &s);
 std::string itos(int i);
 std::string findDelimiters(const std::string &s, const std::string &c);
 

--- a/ASMC_SRC/SRC/StringUtils.hpp
+++ b/ASMC_SRC/SRC/StringUtils.hpp
@@ -24,7 +24,6 @@ namespace StringUtils {
 
 const std::string RANGE_DELIMS = "{:}";
 
-int stoi(const std::string &s);
 double stod(const std::string &s);
 float stof(const std::string &s);
 std::string itos(int i);

--- a/ASMC_SRC/SRC/StringUtils.hpp
+++ b/ASMC_SRC/SRC/StringUtils.hpp
@@ -24,7 +24,6 @@ namespace StringUtils {
 
 const std::string RANGE_DELIMS = "{:}";
 
-std::string itos(int i);
 std::string findDelimiters(const std::string &s, const std::string &c);
 
 std::vector <std::string> tokenizeMultipleDelimiters(const std::string &s, const std::string &c);


### PR DESCRIPTION
Removes all `scanf` instances, replacing their use with functions from the standard library.