### PR TITLE
Initial eigen port of DecodingReturnValues

### DIFF
--- a/ASMC_SRC/SRC/HMM.hpp
+++ b/ASMC_SRC/SRC/HMM.hpp
@@ -24,6 +24,7 @@
 #include "Types.hpp"
 #include <string>
 #include <vector>
+#include <Eigen/Dense>
 
 using namespace std;
 
@@ -39,16 +40,16 @@ struct PairObservations {
 struct DecodingReturnValues {
 
   /// output for sum over all pairs
-  vector<vector<float>> sumOverPairs;
+  Eigen::ArrayXXf sumOverPairs;
 
   /// output for sum over all pairs with genotype 00
-  vector<vector<float>> sumOverPairs00;
+  Eigen::ArrayXXf sumOverPairs00;
 
   /// output for sum over all pairs with genotype 01 or 10
-  vector<vector<float>> sumOverPairs01;
+  Eigen::ArrayXXf sumOverPairs01;
 
   /// output for sum over all pairs with genotype 11
-  vector<vector<float>> sumOverPairs11;
+  Eigen::ArrayXXf sumOverPairs11;
 
   int sites = 0;
   unsigned int states = 0;
@@ -162,9 +163,6 @@ class HMM {
   private:
   /// resets the internal state of HMM to a clean state
   void resetDecoding();
-
-  /// zero a vector of vectors of type T
-  template <typename T> void zeroVectorOfVectors(vector<vector<T>>& v);
 
   void prepareEmissions();
 

--- a/ASMC_SRC/SRC/main.cpp
+++ b/ASMC_SRC/SRC/main.cpp
@@ -26,6 +26,7 @@
 #include "HMM.hpp"
 #include "StringUtils.hpp"
 #include "Timer.hpp"
+#include <Eigen/Dense>
 
 using namespace std;
 
@@ -48,6 +49,9 @@ int main(int argc, char* argv[])
     cerr << "Error processing command line; exiting." << endl;
     exit(1);
   }
+
+  // Eigen output formatter to match original ASMC output
+  Eigen::IOFormat TabFmt(Eigen::StreamPrecision, Eigen::DontAlignCols, "\t", "\n");
 
   cout << "\n";
 
@@ -124,7 +128,7 @@ int main(int argc, char* argv[])
     FileUtils::AutoGzOfstream fout;
     fout.openOrExit(params.outFileRoot + ".sumOverPairs.gz");
     cout << "Output file: " << params.outFileRoot << ".sumOverPairs.gz" << endl;
-    fout << decodingReturnValues.sumOverPairs << endl;
+    fout << decodingReturnValues.sumOverPairs.format(TabFmt) << endl;
     fout.close();
   }
   if (params.doMajorMinorPosteriorSums) {
@@ -148,7 +152,7 @@ int main(int argc, char* argv[])
     // Sum for 01
     FileUtils::AutoGzOfstream fout01;
     fout01.openOrExit(params.outFileRoot + ".01.sumOverPairs.gz");
-    fout01 << decodingReturnValues.sumOverPairs01 << endl;
+    fout01 << decodingReturnValues.sumOverPairs01.format(TabFmt) << endl;
     fout01.close();
     // Sum for 11
     FileUtils::AutoGzOfstream fout11;

--- a/ASMC_SRC/SRC/main.cpp
+++ b/ASMC_SRC/SRC/main.cpp
@@ -118,27 +118,16 @@ int main(int argc, char* argv[])
 
   hmm.decodeAll(params.jobs, params.jobInd);
   const DecodingReturnValues& decodingReturnValues = hmm.getDecodingReturnValues();
-  const vector<vector<float>>& sumOverPairs = decodingReturnValues.sumOverPairs;
 
   // output sums over pairs (if requested)
   if (params.doPosteriorSums) {
     FileUtils::AutoGzOfstream fout;
     fout.openOrExit(params.outFileRoot + ".sumOverPairs.gz");
     cout << "Output file: " << params.outFileRoot << ".sumOverPairs.gz" << endl;
-    for (int pos = 0; pos < data.sites; pos++) {
-      for (uint k = 0; k < decodingQuantities.states; k++) {
-        if (k)
-          fout << "\t";
-        fout << sumOverPairs[pos][k];
-      }
-      fout << endl;
-    }
+    fout << decodingReturnValues.sumOverPairs << endl;
     fout.close();
   }
   if (params.doMajorMinorPosteriorSums) {
-    vector<vector<float>> sumOverPairs00 = decodingReturnValues.sumOverPairs00;
-    vector<vector<float>> sumOverPairs01 = decodingReturnValues.sumOverPairs01;
-    vector<vector<float>> sumOverPairs11 = decodingReturnValues.sumOverPairs11;
     // Sum for 00
     FileUtils::AutoGzOfstream fout00;
     fout00.openOrExit(params.outFileRoot + ".00.sumOverPairs.gz");
@@ -147,9 +136,9 @@ int main(int argc, char* argv[])
         if (k)
           fout00 << "\t";
         if (!data.siteWasFlippedDuringFolding[pos]) {
-          fout00 << sumOverPairs00[pos][k];
+          fout00 << decodingReturnValues.sumOverPairs00(pos,k);
         } else {
-          fout00 << sumOverPairs11[pos][k];
+          fout00 << decodingReturnValues.sumOverPairs11(pos,k);
         }
       }
       fout00 << endl;
@@ -159,14 +148,7 @@ int main(int argc, char* argv[])
     // Sum for 01
     FileUtils::AutoGzOfstream fout01;
     fout01.openOrExit(params.outFileRoot + ".01.sumOverPairs.gz");
-    for (int pos = 0; pos < data.sites; pos++) {
-      for (uint k = 0; k < decodingQuantities.states; k++) {
-        if (k)
-          fout01 << "\t";
-        fout01 << sumOverPairs01[pos][k];
-      }
-      fout01 << endl;
-    }
+    fout01 << decodingReturnValues.sumOverPairs01 << endl;
     fout01.close();
     // Sum for 11
     FileUtils::AutoGzOfstream fout11;
@@ -176,9 +158,9 @@ int main(int argc, char* argv[])
         if (k)
           fout11 << "\t";
         if (!data.siteWasFlippedDuringFolding[pos]) {
-          fout11 << sumOverPairs11[pos][k];
+          fout11 << decodingReturnValues.sumOverPairs11(pos,k);
         } else {
-          fout11 << sumOverPairs00[pos][k];
+          fout11 << decodingReturnValues.sumOverPairs00(pos,k);
         }
       }
       fout11 << endl;

--- a/ASMC_SRC/SRC/pybind.cpp
+++ b/ASMC_SRC/SRC/pybind.cpp
@@ -56,7 +56,7 @@ PYBIND11_MODULE(pyASMC, m) {
     py::bind_vector<std::vector<Individual>>(m, "VectorIndividual");
     py::bind_vector<std::vector<uint>>(m, "VectorUInt");
     py::bind_vector<std::vector<PairObservations>>(m, "VectorPairObservations");
-    //py::bind_vector<std::vector<std::vector<float>>>(m, "Matrix");
+    py::bind_vector<std::vector<std::vector<float>>>(m, "Matrix");
     py::bind_map<std::unordered_map<float, std::vector<float>>>(m, "UMapFloatToVectorFloat");
     py::bind_map<std::unordered_map<int, std::vector<float>>>(m, "UMapIntToVectorFloat");
     py::class_<DecodingReturnValues>(m, "DecodingReturnValues")

--- a/ASMC_SRC/SRC/pybind.cpp
+++ b/ASMC_SRC/SRC/pybind.cpp
@@ -17,6 +17,7 @@
 #include <vector>
 #include <pybind11/stl_bind.h>
 #include <pybind11/stl.h>
+#include <pybind11/eigen.h>
 #include "ASMC.hpp"
 #include "Individual.hpp"
 #include "HMM.hpp"
@@ -26,7 +27,7 @@
 
 PYBIND11_MAKE_OPAQUE(std::vector<bool>)
 PYBIND11_MAKE_OPAQUE(std::vector<float>)
-PYBIND11_MAKE_OPAQUE(std::vector <std::vector <float> >)
+//PYBIND11_MAKE_OPAQUE(std::vector <std::vector <float> >)
 PYBIND11_MAKE_OPAQUE(std::vector<Individual>)
 PYBIND11_MAKE_OPAQUE(std::vector<PairObservations>)
 PYBIND11_MAKE_OPAQUE(std::unordered_map<float, std::vector<float>>)
@@ -55,7 +56,7 @@ PYBIND11_MODULE(pyASMC, m) {
     py::bind_vector<std::vector<Individual>>(m, "VectorIndividual");
     py::bind_vector<std::vector<uint>>(m, "VectorUInt");
     py::bind_vector<std::vector<PairObservations>>(m, "VectorPairObservations");
-    py::bind_vector<std::vector<std::vector<float>>>(m, "Matrix");
+    //py::bind_vector<std::vector<std::vector<float>>>(m, "Matrix");
     py::bind_map<std::unordered_map<float, std::vector<float>>>(m, "UMapFloatToVectorFloat");
     py::bind_map<std::unordered_map<int, std::vector<float>>>(m, "UMapIntToVectorFloat");
     py::class_<DecodingReturnValues>(m, "DecodingReturnValues")

--- a/ASMC_SRC/TESTS/test_asmc.py
+++ b/ASMC_SRC/TESTS/test_asmc.py
@@ -26,6 +26,11 @@ class TestASMC(unittest.TestCase):
     def test_initialization(self):
         self.assertGreater(len(self.data.individuals), 20)
 
+    def test_sum_over_pairs_shape(self):
+        ret = self.hmm.getDecodingReturnValues()
+        self.assertEqual(ret.sumOverPairs.shape,
+                         (self.sequenceLength, self.decodingQuantities.states))
+
     def test_decode_pair(self):
         self.assertEqual(len(self.hmm.getBatchBuffer()), 0)
         self.hmm.decodePair(0, 9)

--- a/ASMC_SRC/TESTS/test_regression.cpp
+++ b/ASMC_SRC/TESTS/test_regression.cpp
@@ -54,18 +54,17 @@ TEST_CASE("test hmm with regression test", "[HMM_regression]")
     fin.openOrExit(regressionFile);
     hmm.decodeAll(params.jobs, params.jobInd);
     const DecodingReturnValues& decodingReturnValues = hmm.getDecodingReturnValues();
-    const vector<vector<float>>& sumOverPairs = decodingReturnValues.sumOverPairs;
     int pos = 0;
     for( std::string line; getline(fin, line); )
     {
       std::ostringstream oss;
       for (uint k = 0; k < decodingQuantities.states; k++) {
         if (k) oss << "\t";
-        oss << sumOverPairs[pos][k];
+        oss << decodingReturnValues.sumOverPairs(pos,k);
       }
       REQUIRE(oss.str() == line);
       pos++;
     }
-    REQUIRE(pos == sumOverPairs.size());
+    REQUIRE(pos == decodingReturnValues.sumOverPairs.rows());
   }
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,10 @@ find_package(Boost REQUIRED COMPONENTS program_options iostreams)
 target_link_libraries(ASMC PRIVATE ${Boost_LIBRARIES})
 target_include_directories(ASMC PUBLIC ${Boost_INCLUDE_DIR})
 
+# Eigen is required
+find_package(Eigen3 REQUIRED)
+target_include_directories(ASMC PUBLIC ${EIGEN3_INCLUDE_DIRS})
+
 # zlib is required (at least on Linux) for boost iostreams
 find_package(ZLIB REQUIRED)
 target_link_libraries(ASMC PRIVATE ZLIB::ZLIB)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,9 +68,9 @@ pool:
   vmImage: $(imageName)
 
 variables:
-  aptDeps: 'libboost-all-dev lcov'
-  brewDeps: 'boost libomp'
-  vcpkgDeps: 'boost-algorithm boost-align boost-iostreams boost-program-options boost-math zlib'
+  aptDeps: 'libboost-all-dev lcov libeigen3-dev'
+  brewDeps: 'boost libomp eigen'
+  vcpkgDeps: 'boost-algorithm boost-align boost-iostreams boost-program-options boost-math zlib eigen'
 
 steps:
 


### PR DESCRIPTION
This commit ports sumOverPairs{,00,01,11} to use Eigen Arrays. Eigen
arrays are automatically converted to numpy arrays by pybind and support
useful array and matrix operations.